### PR TITLE
#23fix mathjax

### DIFF
--- a/app/javascript/src/MathJax.js
+++ b/app/javascript/src/MathJax.js
@@ -1,6 +1,5 @@
 MathJax = {
   loader: {load: ['[tex]/tagformat']}, // lazy load -> 'ui/lazy',
-  section: 0,
   tex: {
     packages: {'[+]': ['tagformat', 'sections']},
     inlineMath: [ ['$','$'], ['\\(','\\)'] ],
@@ -19,7 +18,6 @@ MathJax = {
         nextSection: 'NextSection'
       }, {
         NextSection(parser, name) {
-          MathJax.config.section++;
           parser.tags.counter = parser.tags.allCounter = 0;
         }
       });
@@ -27,12 +25,6 @@ MathJax = {
         'sections', {handler: {macro: ['sections']}}
       );
       MathJax.startup.defaultReady();
-      MathJax.startup.input[0].preFilters.add(({math}) => {
-        if (math.inputData.recompile) MathJax.config.section = math.inputData.recompile.section;
-      });
-      MathJax.startup.input[0].postFilters.add(({math}) => {
-        if (math.inputData.recompile) math.inputData.recompile.section = MathJax.config.section;
-      });
       // タイプセットが終了したのちの処理
       MathJax.startup.promise.then(() => {
         removeBrTagsAfterDisplayMath();

--- a/app/views/answers/_point_in_index.html.slim
+++ b/app/views/answers/_point_in_index.html.slim
@@ -4,8 +4,8 @@
       = Answer.human_attribute_name(:point)
     .p-2.point.mathjax-initialize-typeset
       == answer.point
-    span style="visibility: hidden;"
-      | \(\nextSection\)
+      span style="display: none;"
+        | \(\nextSection\)
   - else
     label.me-3
       = Answer.human_attribute_name(:point)

--- a/app/views/answers/index.html.slim
+++ b/app/views/answers/index.html.slim
@@ -25,7 +25,7 @@
 
   .py-1
 
-  = t(".search_result_count", record_count: @answers.size)
+  = t(".search_result_count", record_count: @pagy.count)
 
 .py-4
 

--- a/app/views/answers/show.html.slim
+++ b/app/views/answers/show.html.slim
@@ -108,7 +108,7 @@ div id="answer_#{@answer.id}"
             = Answer.human_attribute_name(:point)
           .point-field.mathjax-initialize-typeset
             == @answer.point
-            span style="visibility: hidden;"
+            span style="display: none;"
               | \(\nextSection\)
 
           .py-2.py-lg-3

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -10,7 +10,7 @@ div  id="comment-#{comment.id}"
           | #{comment.created_elapsed_time}前
       .comment-body
         == comment.body
-        span style="visibility: hidden;"
+        span style="display: none;"
           | \(\nextSection\)
 
       - if current_user&.commented?(comment)

--- a/app/views/shared/questions/_index.html.slim
+++ b/app/views/shared/questions/_index.html.slim
@@ -80,7 +80,7 @@
 
   .py-1
 
-  = t(".search_result_count", record_count: questions.size)
+  = t(".search_result_count", record_count: pagy.count)
 
 .py-4
 


### PR DESCRIPTION
# 概要
issue #51 にあるように、ポイントのMathJaxタイプセット時に、数式番号が複数の解答でひと続きになるバグを修正しました。

# 修正内容
ビューファイルの
```
  span style="display: none;"
    | \(\nextSection\)
```
のインデントを修正することで解決しました。

# その他変更点
MathJaxの設定のうち、sectionに関するものは不要なので削除しました。

# チェックリスト
- [ ] rubocopをパスした
- [ ] rails_best_practicesをパスした
- [ ] モデルスペックを作成し、パスした
- [ ] システムスペックを作成し、パスした
