### PR TITLE
AWS CloudFrontのキャッシュを利用する設定を追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/integer/time"
-
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -41,6 +40,8 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :amazon
+  # Active Storageがデフォルトでプロキシを利用するように設定
+  config.active_storage.resolve_model_to_route = :cdn_proxy
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,7 +13,8 @@ amazon:
   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
   region: ap-northeast-1
   bucket: nyushisugakunohiroba-bucket
-  # public: true
+  upload:
+    cache_control: "max-age=604800, must-revalidate"
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
## 概要
#59 をご覧ください。

## 確認方法
- ActiveStorageファイルのURLがCDNに向いていること
- ActiveStorageファイルのレスポンスのcash-controlヘッダーの値が設定通りになっていること

## チェックリスト
- [ ] rubocopをパスした
- [ ] rails_best_practicesをパスした
- [ ] モデルスペックを作成し、パスした
- [ ] システムスペックを作成し、パスした

