### PR TITLE
#30refactoring form object

### DIFF
--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -5,7 +5,7 @@ class Admin::QuestionsController < Admin::ApplicationController
   before_action :set_question_association_without_image, only: %i[edit]
 
   def index
-    @questions_search_form = QuestionsSearchForm.new(specific_search_condition: QuestionsSearchForm::SPECIFIC_CONDITIONS_ENUM[:all_data])
+    @questions_search_form = QuestionsSearchForm.new(specific_search_condition: Search::SearchBase::SPECIFIC_CONDITIONS[:all_data])
     @pagy, @questions = pagy(@questions_search_form.search.with_attached_image.includes({ departments: [:university] }, :questions_units_mediators, { questions_departments_mediators: [:department] }), link_extra: 'data-remote="true" class="loading page-link"')
   end
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -6,7 +6,7 @@ class AnswersController < ApplicationController
   def index
     # 解答作成者でないユーザーがアクセスしたら、トップへリダイレクトする
     redirect_to root_path unless params[:user_id] == current_user.id
-    @answers_search_form = AnswersSearchForm.new(specific_search_condition: AnswersSearchForm::SPECIFIC_CONDITIONS_ENUM[:all_data])
+    @answers_search_form = AnswersSearchForm.new(specific_search_condition: Search::SearchBase::SPECIFIC_CONDITIONS[:all_data])
     @pagy, @answers = pagy(@answers_search_form.search(current_user).includes(:rich_text_point, :tags, question: { departments: :university, image_attachment: :blob }), link_extra: 'data-remote="true" class="loading page-link"')
   end
 
@@ -132,3 +132,5 @@ class AnswersController < ApplicationController
     gon.tags = @question.tags_belongs_to_same_unit_of_user(current_user).pluck(:name)
   end
 end
+
+class Takashi; end

--- a/app/controllers/answers_tags_controller.rb
+++ b/app/controllers/answers_tags_controller.rb
@@ -3,7 +3,7 @@
 class AnswersTagsController < ApplicationController
   def index
     tags_search_form = TagsSearchForm.new(tags_search_form_params)
-    tags = tags_search_form.search_from_answers(current_user)
+    tags = tags_search_form.search(current_user)
     render json: tags.map { |tag| { value: tag.name, count: tag.count } }
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -4,7 +4,7 @@ class QuestionsController < ApplicationController
   skip_before_action :require_login
 
   def index
-    @questions_search_form = QuestionsSearchForm.new(specific_search_condition: QuestionsSearchForm::SPECIFIC_CONDITIONS_ENUM[:all_data])
+    @questions_search_form = QuestionsSearchForm.new(specific_search_condition: Search::SearchBase::SPECIFIC_CONDITIONS[:all_data])
     @pagy, @questions = pagy(@questions_search_form.search.with_attached_image.includes({ departments: :university }, :questions_units_mediators, { questions_departments_mediators: :department }), link_extra: 'data-remote="true" class="loading page-link"')
     @question_id_to_answer_id_hash_of_user = logged_in? ? current_user.question_id_to_answer_id_hash : {}
   end

--- a/app/controllers/questions_tags_controller.rb
+++ b/app/controllers/questions_tags_controller.rb
@@ -5,7 +5,7 @@ class QuestionsTagsController < ApplicationController
 
   def index
     tags_search_form = TagsSearchForm.new(tags_search_form_params)
-    tags = tags_search_form.search_from_questions
+    tags = tags_search_form.search
     render json: tags.map { |tag| { value: tag.name, taggings_count: tag.taggings_count } }
   end
 

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -4,7 +4,7 @@ class TopController < ApplicationController
   skip_before_action :require_login, only: [:show]
 
   def show
-    @questions_search_form = QuestionsSearchForm.new(specific_search_condition: QuestionsSearchForm::SPECIFIC_CONDITIONS_ENUM[:all_data], sort_type: "answers_many")
+    @questions_search_form = QuestionsSearchForm.new(specific_search_condition: Search::SearchBase::SPECIFIC_CONDITIONS[:all_data], sort_type: "answers_many")
     @questions = @questions_search_form.search.limit(2).with_attached_image.includes({ departments: :university }, :questions_units_mediators, { questions_departments_mediators: :department })
     @question_id_to_answer_id_hash_of_user = logged_in? ? current_user.question_id_to_answer_id_hash : {}
     @answers = Answer.all.includes(:rich_text_point, :tags, user: { avatar_attachment: :blob }, question: { departments: :university, image_attachment: :blob }).order(created_at: :desc).limit(2)

--- a/app/forms/answers_search_form.rb
+++ b/app/forms/answers_search_form.rb
@@ -15,7 +15,7 @@ class AnswersSearchForm
   attribute :sort_type, :string, default: -> { "year_new" }
   attribute :search_condition_messages
 
-  def search(user)
+  def search(user = nil)
     answers_search = Search::AnswersSearch.new(search_conditions.merge({ user: }))
     answers_sort = Sort::AnswersSort.new(sort_conditions)
     self.search_condition_messages = answers_search.build_search_condition_messages

--- a/app/forms/answers_search_form.rb
+++ b/app/forms/answers_search_form.rb
@@ -2,82 +2,41 @@
 
 class AnswersSearchForm
   SORT_TYPES = %w[year_new updated_at_new like_many comment_new].each(&:freeze).freeze
-  SPECIFIC_CONDITIONS_ENUM = { nothing: 0, no_data: 1, all_data: 2 }.each_value(&:freeze).freeze
 
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attribute :specific_search_condition, :integer, default: -> { SPECIFIC_CONDITIONS_ENUM[:nothing] }
+  attribute :specific_search_condition
   attribute :university_ids
   attribute :start_year, :integer
   attribute :end_year, :integer
   attribute :unit_ids
   attribute :tag_names, :string, default: -> { "" }
   attribute :sort_type, :string, default: -> { "year_new" }
-  # 条件表示の変数
-  attribute :search_conditions, default: lambda { \
-    { \
-      university: "なし", \
-      question_year: "なし", \
-      unit: "なし", \
-      tag: "なし" \
-    } \
-  }
+  attribute :search_condition_messages
 
   def search(user)
-    case specific_search_condition
-    when SPECIFIC_CONDITIONS_ENUM[:no_data]
-      relation = Answer.none
-    when SPECIFIC_CONDITIONS_ENUM[:all_data]
-      relation = user.answers
-    when SPECIFIC_CONDITIONS_ENUM[:nothing]
-      university_ids_no_blank = university_ids&.reject(&:blank?)
-      unit_ids_no_blank = unit_ids&.reject(&:blank?)
-      # tag_names="tag1, tag2"をtag_list=["tag1", "tag2"]へ
-      tag_name_array = tag_names.split(",")
+    answers_search = Search::AnswersSearch.new(search_conditions.merge({ user: }))
+    answers_sort = Sort::AnswersSort.new(sort_conditions)
+    self.search_condition_messages = answers_search.build_search_condition_messages
+    answers = answers_search.search
+    answers_sort.sort(answers)
+  end
 
-      relation = user.answers
+  private
 
-      # 大学名によるanswerの絞り込み
-      if university_ids_no_blank.present?
-        relation = relation.by_university_ids(university_ids_no_blank).distinct
-        search_conditions[:university] = University.find(university_ids_no_blank).pluck(:name).join("、")
-      end
+  def search_conditions
+    {
+      specific_search_condition:,
+      tag_names:,
+      university_ids:,
+      unit_ids:,
+      start_year:,
+      end_year:
+    }
+  end
 
-      # 出題年によるanswerの絞り込み
-      if start_year.present? || end_year.present?
-        self.start_year = Question.minimum(:year) if start_year.blank?
-        self.end_year = Question.maximum(:year) if end_year.blank?
-        relation = relation.by_year(start_year, end_year)
-        search_conditions[:question_year] = "#{start_year} 年 〜 #{end_year} 年"
-      end
-
-      # 単元によるanswerの絞り込み
-      if unit_ids_no_blank.present?
-        relation = relation.by_unit_ids(unit_ids_no_blank)
-        search_conditions[:unit] = Unit.find(unit_ids_no_blank).pluck(:name).join("、")
-      end
-
-      # タグによるanswerの絞り込み
-      if tag_name_array.present?
-        relation = relation.by_tag_name_array(tag_name_array)
-        search_conditions[:tag] = tag_name_array.join("、")
-      end
-    end
-
-    # 並び替え
-    case sort_type
-    when "year_new"
-      relation = Answer.joins(:question).where(answers: { id: relation.select(:id) }).select("answers.*, questions.year").order(Arel.sql("questions.year desc"))
-    when "updated_at_new"
-      relation = relation.order(updated_at: :desc)
-    when "like_many"
-      relation = relation.order(likes_count: :desc)
-    when "comment_new"
-      sql_to_get_newest_comment_date = "COALESCE(MAX(comments.created_at), '0001-01-01')"
-      relation = Answer.left_joins(:comments).where(answers: { id: relation.select(:id) }).select("answers.*, #{sql_to_get_newest_comment_date}").group("answers.id").order(Arel.sql("#{sql_to_get_newest_comment_date} desc"))
-    end
-
-    relation
+  def sort_conditions
+    { sort_type: }
   end
 end

--- a/app/forms/questions_search_form.rb
+++ b/app/forms/questions_search_form.rb
@@ -2,80 +2,41 @@
 
 class QuestionsSearchForm
   SORT_TYPES = %w[year_new created_at_new answers_many].each(&:freeze).freeze
-  SPECIFIC_CONDITIONS_ENUM = { nothing: 0, no_data: 1, all_data: 2 }.each_value(&:freeze).freeze
 
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attribute :specific_search_condition, :integer, default: -> { SPECIFIC_CONDITIONS_ENUM[:nothing] }
+  attribute :specific_search_condition, :integer
   attribute :university_ids
   attribute :start_year, :integer
   attribute :end_year, :integer
   attribute :unit_ids
   attribute :tag_names, :string, default: -> { "" }
   attribute :sort_type, :string, default: -> { "year_new" }
-  # 条件表示の変数
-  attribute :search_conditions, default: lambda { \
-    { \
-      university: "なし", \
-      question_year: "なし", \
-      unit: "なし", \
-      tag: "なし" \
-    } \
-  }
+  attribute :search_condition_messages
 
   def search
-    case specific_search_condition
-    when SPECIFIC_CONDITIONS_ENUM[:no_data]
-      relation = Question.none
-    when SPECIFIC_CONDITIONS_ENUM[:all_data]
-      relation = Question.all
-    when SPECIFIC_CONDITIONS_ENUM[:nothing]
-      university_ids_no_blank = university_ids&.reject(&:blank?)
-      unit_ids_no_blank = unit_ids&.reject(&:blank?)
-      # tag_names="tag1, tag2"をtag_list=["tag1", "tag2"]へ
-      tag_name_array = tag_names.split(",")
+    questions_search = Search::QuestionsSearch.new(search_conditions)
+    questions_sort = Sort::QuestionsSort.new(sort_conditions)
+    self.search_condition_messages = questions_search.build_search_condition_messages
+    questions = questions_search.search
+    questions_sort.sort(questions)
+  end
 
-      relation = Question.all
+  private
 
-      # 大学名によるquestionの絞り込み
-      if university_ids_no_blank.present?
-        relation = relation.by_university_ids(university_ids_no_blank).distinct
-        search_conditions[:university] = University.find(university_ids_no_blank).pluck(:name).join("、")
-      end
+  def search_conditions
+    {
+      specific_search_condition:,
+      tag_names:,
+      university_ids:,
+      unit_ids:,
+      start_year:,
+      end_year:
+    }
+  end
 
-      # 出題年によるquestionの絞り込み
-      if start_year.present? || end_year.present?
-        self.start_year = Question.minimum(:year) if start_year.blank?
-        self.end_year = Question.maximum(:year) if end_year.blank?
-        relation = relation.by_year(start_year, end_year).distinct
-        search_conditions[:question_year] = "#{start_year} 年 〜 #{end_year} 年"
-      end
-
-      # 単元によるquestionの絞り込み
-      if unit_ids_no_blank.present?
-        relation = relation.by_unit_ids(unit_ids_no_blank)
-        search_conditions[:unit] = Unit.find(unit_ids_no_blank).pluck(:name).join("、")
-      end
-
-      # タグによるquestionの絞り込み
-      if tag_name_array.present?
-        relation = relation.by_tag_name_array(tag_name_array).distinct
-        search_conditions[:tag] = tag_name_array.join("、")
-      end
-    end
-
-    # 並び替え
-    case sort_type
-    when "year_new"
-      relation = relation.order(year: :desc)
-    when "created_at_new"
-      relation = relation.order(created_at: :desc)
-    when "answers_many"
-      # relation = Question.left_joins(:answers).where(questions: { id: relation.select(:id) }).select("questions.*, COUNT(DISTINCT answers.id)").group("questions.id").order(Arel.sql("COUNT(DISTINCT answers.id) desc"))
-      relation = relation.order(answers_count: :desc)
-    end
-
-    relation
+  def sort_conditions
+    { sort_type: }
   end
 end

--- a/app/forms/questions_search_form.rb
+++ b/app/forms/questions_search_form.rb
@@ -7,13 +7,13 @@ class QuestionsSearchForm
   include ActiveModel::Attributes
 
   attribute :specific_search_condition, :integer
-  attribute :university_ids
+  attribute :university_ids # array
   attribute :start_year, :integer
   attribute :end_year, :integer
-  attribute :unit_ids
+  attribute :unit_ids # array
   attribute :tag_names, :string, default: -> { "" }
   attribute :sort_type, :string, default: -> { "year_new" }
-  attribute :search_condition_messages
+  attribute :search_condition_messages # ハッシュ
 
   def search
     questions_search = Search::QuestionsSearch.new(search_conditions)

--- a/app/forms/search/answers_search.rb
+++ b/app/forms/search/answers_search.rb
@@ -5,7 +5,7 @@ module Search
     attribute :user
 
     def searchable_relation
-      user.answers
+      user ? user.answers : Answer.all
     end
   end
 end

--- a/app/forms/search/answers_search.rb
+++ b/app/forms/search/answers_search.rb
@@ -4,6 +4,8 @@ module Search
   class AnswersSearch < SearchBase
     attribute :user
 
+    # user を指定した場合：ユーザーの解答を検索
+    # user = nil の場合：全ユーザーの解答を検索
     def searchable_relation
       user ? user.answers : Answer.all
     end

--- a/app/forms/search/answers_search.rb
+++ b/app/forms/search/answers_search.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Search
+  class AnswersSearch < SearchBase
+    attribute :user
+
+    def searchable_relation
+      user.answers
+    end
+  end
+end

--- a/app/forms/search/questions_search.rb
+++ b/app/forms/search/questions_search.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Search
+  class QuestionsSearch < SearchBase
+    def searchable_relation
+      Question.all
+    end
+  end
+end

--- a/app/forms/search/search_base.rb
+++ b/app/forms/search/search_base.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Search
+  class SearchBase
+    SPECIFIC_CONDITIONS_ENUM = { no_data: 0, all_data: 1 }.each_value(&:freeze).freeze
+
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :specific_search_condition, :integer
+    attribute :university_ids
+    attribute :start_year, :integer
+    attribute :end_year, :integer
+    attribute :unit_ids
+    attribute :tag_names, :string
+
+    def search
+      # 絞り込み
+      case specific_search_condition
+      when SPECIFIC_CONDITIONS_ENUM[:no_data]
+        relation = searchable_relation.none
+      when SPECIFIC_CONDITIONS_ENUM[:all_data]
+        relation = searchable_relation
+      else
+        relation = searchable_relation
+
+        # 大学名によるquestionの絞り込み
+        relation = relation.by_university_ids(university_ids_no_blank) if university_ids_no_blank.present?
+
+        # 出題年によるquestionの絞り込み
+        if start_year.present? || end_year.present?
+          fill_in_year
+          relation = relation.by_year(start_year, end_year)
+        end
+
+        # 単元によるquestionの絞り込み
+        relation = relation.by_unit_ids(unit_ids_no_blank) if unit_ids_no_blank.present?
+
+        # タグによるquestionの絞り込み
+        relation = relation.by_tag_name_array(tag_name_array) if tag_name_array.present?
+      end
+
+      relation
+    end
+
+    def build_search_condition_messages
+      { university: university_message,
+        question_year: question_year_message,
+        unit: unit_message,
+        tag: tag_message }
+    end
+
+    private
+
+    def university_ids_no_blank
+      university_ids&.reject(&:blank?)
+    end
+
+    def unit_ids_no_blank
+      unit_ids&.reject(&:blank?)
+    end
+
+    def tag_name_array
+      tag_names&.split(",") # tag_names="tag1, tag2"をtag_list=["tag1", "tag2"]へ
+    end
+
+    def university_message
+      university_ids_no_blank.present? ? University.find(university_ids_no_blank).pluck(:name).join("、") : "なし"
+    end
+
+    def question_year_message
+      array = [start_year.present?, end_year.present?]
+      case array
+      when [true, true]
+        "#{start_year} 年 〜 #{end_year} 年"
+      when [true, false]
+        "#{start_year} 年 〜 "
+      when [false, true]
+        " 〜 #{end_year} 年"
+      when [false, false]
+        "なし"
+      end
+    end
+
+    def unit_message
+      unit_ids_no_blank.present? ? Unit.find(unit_ids_no_blank).pluck(:name).join("、") : "なし"
+    end
+
+    def tag_message
+      tag_name_array.present? ? tag_name_array.join("、") : "なし"
+    end
+
+    def searchable_relation
+      nil
+    end
+
+    def fill_in_year
+      self.start_year = 0 if start_year.blank?
+      self.end_year = Time.current.year if end_year.blank?
+    end
+  end
+end

--- a/app/forms/search/search_base.rb
+++ b/app/forms/search/search_base.rb
@@ -24,19 +24,19 @@ module Search
       else
         relation = searchable_relation
 
-        # 大学名によるquestionの絞り込み
+        # 大学名による絞り込み
         relation = relation.by_university_ids(university_ids_no_blank) if university_ids_no_blank.present?
 
-        # 出題年によるquestionの絞り込み
+        # 出題年による絞り込み
         if start_year.present? || end_year.present?
           fill_in_year
           relation = relation.by_year(start_year, end_year)
         end
 
-        # 単元によるquestionの絞り込み
+        # 単元による絞り込み
         relation = relation.by_unit_ids(unit_ids_no_blank) if unit_ids_no_blank.present?
 
-        # タグによるquestionの絞り込み
+        # タグによる絞り込み
         relation = relation.by_tag_name_array(tag_name_array) if tag_name_array.present?
       end
 
@@ -51,6 +51,10 @@ module Search
     end
 
     private
+
+    def searchable_relation
+      nil
+    end
 
     def university_ids_no_blank
       university_ids&.reject(&:blank?)
@@ -88,10 +92,6 @@ module Search
 
     def tag_message
       tag_name_array.present? ? tag_name_array.join("、") : "なし"
-    end
-
-    def searchable_relation
-      nil
     end
 
     def fill_in_year

--- a/app/forms/search/search_base.rb
+++ b/app/forms/search/search_base.rb
@@ -2,7 +2,7 @@
 
 module Search
   class SearchBase
-    SPECIFIC_CONDITIONS_ENUM = { no_data: 0, all_data: 1 }.each_value(&:freeze).freeze
+    SPECIFIC_CONDITIONS = { no_data: 0, all_data: 1 }.each_value(&:freeze).freeze
 
     include ActiveModel::Model
     include ActiveModel::Attributes
@@ -17,9 +17,9 @@ module Search
     def search
       # 絞り込み
       case specific_search_condition
-      when SPECIFIC_CONDITIONS_ENUM[:no_data]
+      when SPECIFIC_CONDITIONS[:no_data]
         relation = searchable_relation.none
-      when SPECIFIC_CONDITIONS_ENUM[:all_data]
+      when SPECIFIC_CONDITIONS[:all_data]
         relation = searchable_relation
       else
         relation = searchable_relation

--- a/app/forms/sort/answers_sort.rb
+++ b/app/forms/sort/answers_sort.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Sort
+  class AnswersSort < SortBase
+    YEAR_NEW = lambda { |answers|
+      Answer.joins(:question).where(answers: { id: answers.select(:id) }).select("answers.*, questions.year").order(Arel.sql("questions.year desc"))
+    }
+    UPDATED_AT_NEW = ->(answers) { answers.order(updated_at: :desc) }
+    LIKE_MANY = ->(answers) { answers.order(likes_count: :desc) }
+    COMMENT_NEW = lambda { |answers|
+      sql_to_get_newest_comment_date = "COALESCE(MAX(comments.created_at), '0001-01-01')"
+      Answer.left_joins(:comments).where(answers: { id: answers.select(:id) }).select("answers.*, #{sql_to_get_newest_comment_date}").group("answers.id").order(Arel.sql("#{sql_to_get_newest_comment_date} desc"))
+    }
+  end
+end

--- a/app/forms/sort/questions_sort.rb
+++ b/app/forms/sort/questions_sort.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Sort
+  class QuestionsSort < SortBase
+    YEAR_NEW = ->(questions) { questions.order(year: :desc) }
+    CREATED_AT_NEW = ->(questions) { questions.order(created_at: :desc) }
+    ANSWERS_MANY = ->(questions) { questions.order(answers_count: :desc) }
+  end
+end

--- a/app/forms/sort/sort_base.rb
+++ b/app/forms/sort/sort_base.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Sort
+  class SortBase
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :sort_type, :string
+
+    def sort(sortable)
+      sort_type_block.call(sortable)
+    end
+
+    private
+
+    def sort_type_block
+      "#{self.class}::#{sort_type.upcase}".constantize
+    end
+  end
+end

--- a/app/forms/tags_search_form.rb
+++ b/app/forms/tags_search_form.rb
@@ -9,20 +9,11 @@ class TagsSearchForm
   attribute :end_year, :integer
   attribute :unit_ids
 
-  def search_from_questions
-    questions_search = Search::QuestionsSearch.new(search_conditions)
-    questions = questions_search.search
-
-    # 取得したquestionsから、付けられた回数の多い順に20個タグを取得する
-    Tag.by_questions(questions).order(taggings_count: :desc).limit(20)
-  end
-
-  def search_from_answers(user)
-    questions_search = Search::QuestionsSearch.new(search_conditions)
-    questions = questions_search.search
-
-    # 取得したquestionsから、付けられた回数の多い順にタグを取得する
-    user.answers.by_questions(questions).tag_counts_on(:tags).order(count: :desc)
+  def search(user = nil)
+    answers_search = Search::AnswersSearch.new(search_conditions.merge({ user: }))
+    answers = answers_search.search
+    # 付けられた回数の多い順にタグを20個取得する
+    answers.tag_counts_on(:tags).order(count: :desc).limit(20)
   end
 
   private

--- a/app/forms/tags_search_form.rb
+++ b/app/forms/tags_search_form.rb
@@ -10,34 +10,29 @@ class TagsSearchForm
   attribute :unit_ids
 
   def search_from_questions
-    questions = Question.all
-
-    # 大学名によるquestionの絞り込み
-    questions = questions.by_university_ids(university_ids).distinct if university_ids.present?
-
-    # 出題年によるquestionの絞り込み
-    questions = questions.by_year(start_year, end_year).distinct if start_year.present? & end_year.present?
-
-    # 単元によるquestionの絞り込み
-    questions = questions.by_unit_ids(unit_ids).distinct if unit_ids.present?
+    questions_search = Search::QuestionsSearch.new(search_conditions)
+    questions = questions_search.search
 
     # 取得したquestionsから、付けられた回数の多い順に20個タグを取得する
     Tag.by_questions(questions).order(taggings_count: :desc).limit(20)
   end
 
   def search_from_answers(user)
-    questions = Question.all
-
-    # 大学名によるquestionの絞り込み
-    questions = questions.by_university_ids(university_ids).distinct if university_ids.present?
-
-    # 出題年によるquestionの絞り込み
-    questions = questions.by_year(start_year, end_year).distinct if start_year.present? & end_year.present?
-
-    # 単元によるquestionの絞り込み
-    questions = questions.by_unit_ids(unit_ids).distinct if unit_ids.present?
+    questions_search = Search::QuestionsSearch.new(search_conditions)
+    questions = questions_search.search
 
     # 取得したquestionsから、付けられた回数の多い順にタグを取得する
     user.answers.by_questions(questions).tag_counts_on(:tags).order(count: :desc)
+  end
+
+  private
+
+  def search_conditions
+    {
+      university_ids:,
+      unit_ids:,
+      start_year:,
+      end_year:
+    }
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,12 +16,4 @@
 #
 class Tag < ApplicationRecord
   has_many :taggings, dependent: :destroy
-
-  scope :by_questions, lambda { |questions| \
-    joins(:taggings)\
-      .joins("INNER JOIN answers ON answers.id = taggings.taggable_id")\
-      .joins("INNER JOIN questions ON answers.question_id = questions.id")\
-      .distinct\
-      .where(questions: { id: questions.map(&:id) })
-  }
 end

--- a/app/views/answers/_search_conditions.html.slim
+++ b/app/views/answers/_search_conditions.html.slim
@@ -6,7 +6,7 @@
   small
     / 検索条件を表示
     label
-      | #{AnswersSearchForm.human_attribute_name(:search_conditions)}
+      | #{AnswersSearchForm.human_attribute_name(:search_condition_messages)}
     .py-1
     table.table-sm.table-borderless
       tbody
@@ -16,25 +16,25 @@
           th.align-top.text-nowrap
             | ：
           td.align-top class="university-search-condition"
-            = answers_search_form.search_conditions[:university]
+            = answers_search_form.search_condition_messages[:university]
         tr
           th.align-top.text-nowrap
             = Question.human_attribute_name(:year)
           th.align-top.text-nowrap
             | ：
           td.align-top class="year-search-condition"
-            = answers_search_form.search_conditions[:question_year]
+            = answers_search_form.search_condition_messages[:question_year]
         tr
           th.align-top.text-nowrap
             = Unit.model_name.human
           th.align-top.text-nowrap
             | ：
           td.align-top class="unit-search-condition"
-            = answers_search_form.search_conditions[:unit]
+            = answers_search_form.search_condition_messages[:unit]
         tr
           th.align-top.text-nowrap
             = Tag.model_name.human
           th.align-top.text-nowrap
             | ：
           td.align-top class="tags-search-condition"
-            = answers_search_form.search_conditions[:tag]
+            = answers_search_form.search_condition_messages[:tag]

--- a/app/views/shared/questions/_index.html.slim
+++ b/app/views/shared/questions/_index.html.slim
@@ -11,7 +11,7 @@
 
 / 検索フォーム
 .container.questions-search-form
-  - if questions_search_form.specific_search_condition == QuestionsSearchForm::SPECIFIC_CONDITIONS_ENUM[:all_data]
+  - if questions_search_form.specific_search_condition == Search::SearchBase::SPECIFIC_CONDITIONS[:all_data]
       .container.border.p-3.search-form
           = render search_form_path, questions_search_form: questions_search_form
   - else
@@ -36,7 +36,7 @@
   small
     / 検索条件を表示
     label
-      | #{QuestionsSearchForm.human_attribute_name(:search_conditions)}
+      | #{QuestionsSearchForm.human_attribute_name(:search_condition_messages)}
     .py-1
     table.table-sm.table-borderless
       tbody
@@ -46,21 +46,21 @@
           th.align-top.text-nowrap
             | ：
           td.align-top class="university-search-condition"
-            = questions_search_form.search_conditions[:university]
+            = questions_search_form.search_condition_messages[:university]
         tr
           th.align-top.text-nowrap
             = Question.human_attribute_name(:year)
           th.align-top.text-nowrap
             | ：
           td.align-top class="year-search-condition"
-            = questions_search_form.search_conditions[:question_year]
+            = questions_search_form.search_condition_messages[:question_year]
         tr
           th.align-top.text-nowrap
             = Unit.model_name.human
           th.align-top.text-nowrap
             | ：
           td.align-top class="unit-search-condition"
-            = questions_search_form.search_conditions[:unit]
+            = questions_search_form.search_condition_messages[:unit]
         / 管理画面では検索条件にタグを表示しない
         - unless admin_controller?(controller)
           tr
@@ -69,7 +69,7 @@
             th.align-top.text-nowrap
               | ：
             td.align-top class="tags-search-condition"
-              = questions_search_form.search_conditions[:tag]
+              = questions_search_form.search_condition_messages[:tag]
 
 .py-2
 

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,7 +12,7 @@ ja:
           year_new: "出題年が新しい順"
           created_at_new: "作成日が新しい順"
           answers_many: "解答が多い順"
-        search_conditions: "検索条件"
+        search_condition_messages: "検索条件"
       answers_search_form:
         sort_type:
           one: "並び順"
@@ -20,7 +20,7 @@ ja:
           updated_at_new: "最終更新日が新しい順"
           like_many: "いいねが多い順"
           comment_new: "新しくコメントされた順"
-        search_conditions: "検索条件"
+        search_condition_messages: "検索条件"
       password_reset:
         email: "メールアドレス"
     errors:

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -31,13 +31,5 @@ RSpec.describe Tag, type: :model do
       create(:answer, question: @question_nagoya, user:, tag_names: "tag2")
       create(:answer, question: @question_tokyo, user:, tag_names: "tag3")
     end
-
-    describe "by_questions(questions)" do
-      it "問題でタグを絞れること" do
-        questions = [@question_kyoto, @question_nagoya]
-        tags = Tag.all.by_questions(questions)
-        expect(tags.map(&:name)).to contain_exactly("tag1", "tag2")
-      end
-    end
   end
 end


### PR DESCRIPTION
## 概要
formsディレクトリのコードをリファクタリングしました。
Question、Answer、Tagのフォームオブジェクトの機能のうち、検索、並び替え機能を担当するオブジェクトを以下のように作成し、分離しました。
- 検索機能：Searchオブジェクト群
- 並び替え機能：Sortオブジェクト群

## 影響範囲
なし

## チェックリスト
- [ ] rubocopをパスした
- [ ] rails_best_practicesをパスした
- [ ] モデルスペックを作成し、パスした
- [ ] システムスペックを作成し、パスした

## コメント
Question、Answer、Tagのフォームオブジェクトのコードには重複する内容があり、それらを継承やモジュールのmix-inを利用して取り除くべきか悩みましたが、以下の理由によりそのままにしております。
-  QuestionとAnswerのコードの多くは共通するが、3つのオブジェクトすべてで重複する部分はそれほどないため、3つのオブジェクトのスーパークラスの作成はメリットがない。
- 継承あるいはモジュールを利用してQuestionとAnswerのみのコードを DRYにしたかったが、「それらの間に共通する責務」を見出せなかった。つまり、スーパークラスやモジュールの名前が思い浮かばなかった。このような場合、スーパークラスやモジュールを利用することは単にコードをまとめるためだけに行われることになり、保守性を低めるのではないかと判断した。
今後、フォームオブジェクトが増える場合に、再考の余地があるかと思います。